### PR TITLE
Fixed the correct name of the plugin as it is exists in Dockerhub

### DIFF
--- a/incubating/npm-publish/step.yaml
+++ b/incubating/npm-publish/step.yaml
@@ -45,6 +45,6 @@ spec:
   steps:
     main:
       name: npm-publish
-      image: 'codefresh/npm-publish:latest'
+      image: 'codefreshplugins/npm-publish:latest'
       environment:
         - 'NPM_TOKEN=${{NPM_TOKEN}}'


### PR DESCRIPTION
Reported by a customer who tried to use the plugin and it failed because there is no image codefresh/npm-publish:latest