### PR TITLE
slack-notifier: Add channel param to Slack Request Payload

### DIFF
--- a/incubating/slack-notifier/Dockerfile
+++ b/incubating/slack-notifier/Dockerfile
@@ -4,7 +4,6 @@ RUN apk add --no-cache bash git openssh-client
 
 # Create app directory
 WORKDIR /app/
-VOLUME /app
 
 COPY package.json ./
 
@@ -19,6 +18,9 @@ RUN apk add --no-cache --virtual deps python make g++ krb5-dev && \
 
 # copy app files
 COPY . ./
+
+# mount volume
+VOLUME /app
 
 # run application
 CMD ["node", "/app/index.js"]

--- a/incubating/slack-notifier/README.md
+++ b/incubating/slack-notifier/README.md
@@ -43,9 +43,10 @@ List of env variables
 ```
 
 SLACK_HOOK_URL - required
-SLACK_ATTACHMENTS    - optional
-SLACK_TEXT     - optional
+SLACK_ATTACHMENTS - optional
+SLACK_TEXT - optional
 SLACK_USER_NAME - optional
 SLACK_ICON_EMOJI - optional
+SLACK_CHANNEL - optional
 
 ```

--- a/incubating/slack-notifier/plugin.yml
+++ b/incubating/slack-notifier/plugin.yml
@@ -28,3 +28,5 @@ envs:
   - name: SLACK_TEMPLATE_FIELDS
     type: required
     description: Required in template mode, Override fields in SLACK_TEMPLATE_BODY, should be array. Documentation https://api.slack.com/docs/message-attachments
+  - name: SLACK_CHANNEL
+    description: Optional channel name to send message to instead of the default channel for the SLACK_HOOK_URL.

--- a/incubating/slack-notifier/src/mode/default-template.js
+++ b/incubating/slack-notifier/src/mode/default-template.js
@@ -32,7 +32,7 @@ class DefaultTemplateMode {
         }
         console.log('Choose default-template mode');
 
-        SlackApi.send(process.env.SLACK_TEXT, [template], process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI);
+        SlackApi.send(process.env.SLACK_TEXT, [template], process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI, process.env.SLACK_CHANNEL);
     }
 
 }

--- a/incubating/slack-notifier/src/mode/simple.js
+++ b/incubating/slack-notifier/src/mode/simple.js
@@ -14,7 +14,7 @@ class SimpleMode {
             process.exit(1);
         }
 
-        SlackApi.send(process.env.SLACK_TEXT, attachments, process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI);
+        SlackApi.send(process.env.SLACK_TEXT, attachments, process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI, process.env.SLACK_CHANNEL);
     }
 
 }

--- a/incubating/slack-notifier/src/mode/template.js
+++ b/incubating/slack-notifier/src/mode/template.js
@@ -20,7 +20,7 @@ class TemplateMode {
 
         template.fields = JSON.parse(process.env.SLACK_TEMPLATE_FIELDS);
 
-        SlackApi.send(process.env.SLACK_TEXT, [template], process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI);
+        SlackApi.send(process.env.SLACK_TEXT, [template], process.env.SLACK_USER_NAME, process.env.SLACK_ICON_EMOJI, process.env.SLACK_CHANNEL);
     }
 
 }

--- a/incubating/slack-notifier/src/slack-api.js
+++ b/incubating/slack-notifier/src/slack-api.js
@@ -4,12 +4,13 @@ const slack = new SlackWebhook(process.env.SLACK_HOOK_URL);
 
 class SlackApi {
 
-    static send(text, attachments, username, icon){
+    static send(text, attachments, username, icon, channel){
         slack.send({
             text: text,
             attachments: attachments,
             username: username,
             icon_emoji: icon,
+            channel: channel,
         }).catch(function (err) {
            console.error(`Cant send notification to slack , error : ${err}, check your SLACK_HOOK_URL`);
            process.exitCode = 0;

--- a/incubating/slack-notifier/step.yaml
+++ b/incubating/slack-notifier/step.yaml
@@ -30,6 +30,7 @@ metadata:
               SLACK_HOOK_URL: ${{SLACK_WEBHOOK_URL}}
               SLACK_TEXT: ${{SLACK_TEXT}}
               SLACK_ATTACHMENTS: ${{SLACK_ATTACHMENTS}}
+              SLACK_CHANNEL: ${{SLACK_CHANNEL}}
 spec:
   arguments: |-
     {
@@ -70,6 +71,10 @@ spec:
             "SLACK_TEMPLATE_FIELDS": {
                 "type": "string",
                 "description": "Required in template mode, Override fields in SLACK_TEMPLATE_BODY, should be array. Documentation https://api.slack.com/docs/message-attachments"
+            },
+            "SLACK_CHANNEL": {
+                "type": "string",
+                "description": "Optional channel name to send message to instead of the default channel for the SLACK_HOOK_URL."
             }
         }
     }
@@ -84,3 +89,4 @@ spec:
         - 'MODE=${{MODE}}'
         - 'SLACK_TEMPLATE_BODY=${{SLACK_TEMPLATE_BODY}}'
         - 'SLACK_TEMPLATE_FIELDS=${{SLACK_TEMPLATE_FIELDS}}'
+        - 'SLACK_CHANNEL=${{SLACK_CHANNEL}}'


### PR DESCRIPTION
Add the `channel` param to the Slack request payload and set its value from the optional environment variable `SLACK_CHANNEL` to allow targeting multiple channels for the same Slack webhook URL.