### PR TITLE
fixing typo in image name

### DIFF
--- a/incubating/git-submodules/step.yaml
+++ b/incubating/git-submodules/step.yaml
@@ -61,7 +61,7 @@ spec:
   steps:
     main:
       name: git-submodules
-      image: codefreshplugins/git-submodules
+      image: codefreshplugins/cfstep-gitsubmodules
       environment:
         - 'GITHUB_TOKEN=${{GITHUB_TOKEN}}'
         - 'CF_SUBMODULE_SYNC=${{CF_SUBMODULE_SYNC}}'


### PR DESCRIPTION
@francisco-codefresh Image name was wrong. 

Here is the repository for verification: https://hub.docker.com/r/codefreshplugins/cfstep-gitsubmodules