### PR TITLE
Use printf instead echo

### DIFF
--- a/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
+++ b/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
@@ -78,14 +78,14 @@ if [ "$1" != "" ] && [ "$2" != "" ] && [ "$3" != "" ] && [ "$4" != "" ] && [ "$5
     HEALTH_SECONDS=$5
     NAMESPACE=$6
 else
-    
-    echo "USAGE\n k8s-blue-green-rollout.sh [SERVICE_NAME] [DEPLOYMENT_NAME] [NEW_VERSION] [HEALTH_COMMAND] [HEALTH_SECONDS] [NAMESPACE]"
-    echo "\t [SERVICE_NAME] - Name of the current service"
-    echo "\t [DEPLOYMENT_NAME] - The name of the current deployment"
-    echo "\t [NEW_VERSION] - The next version of the Docker image"
-    echo "\t [HEALTH_COMMAND] - command to use as a health check (unused)"
-    echo "\t [HEALTH_SECONDS] - Time to wait before checking health"
-    echo "\t [NAMESPACE] - Namespace of the application"
+
+    printf "USAGE\n k8s-blue-green-rollout.sh [SERVICE_NAME] [DEPLOYMENT_NAME] [NEW_VERSION] [HEALTH_COMMAND] [HEALTH_SECONDS] [NAMESPACE]\n"
+    printf "\t [SERVICE_NAME] - Name of the current service\n"
+    printf "\t [DEPLOYMENT_NAME] - The name of the current deployment\n"
+    printf "\t [NEW_VERSION] - The next version of the Docker image\n"
+    printf "\t [HEALTH_COMMAND] - command to use as a health check (unused)\n"
+    printf "\t [HEALTH_SECONDS] - Time to wait before checking health\n"
+    printf "\t [NAMESPACE] - Namespace of the application\n"
     exit 1;
 fi
 

--- a/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
+++ b/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
@@ -79,7 +79,7 @@ if [ "$1" != "" ] && [ "$2" != "" ] && [ "$3" != "" ] && [ "$4" != "" ] && [ "$5
     NAMESPACE=$6
 else
 
-    printf "USAGE\n k8s-blue-green-rollout.sh [SERVICE_NAME] [DEPLOYMENT_NAME] [NEW_VERSION] [HEALTH_COMMAND] [HEALTH_SECONDS] [NAMESPACE]\n"
+    printf "USAGE\n %s [SERVICE_NAME] [DEPLOYMENT_NAME] [NEW_VERSION] [HEALTH_COMMAND] [HEALTH_SECONDS] [NAMESPACE]\n" "$0"
     printf "\t [SERVICE_NAME] - Name of the current service\n"
     printf "\t [DEPLOYMENT_NAME] - The name of the current deployment\n"
     printf "\t [NEW_VERSION] - The next version of the Docker image\n"

--- a/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
+++ b/incubating/k8s-blue-green-deployment/k8s-blue-green.sh
@@ -5,7 +5,7 @@ healthcheck(){
     echo "[DEPLOY INFO] Starting Heathcheck"
 
     h=true
-    
+
     #Start custom healthcheck
     output=$(kubectl get pods -l version="$NEW_VERSION" -n $NAMESPACE --no-headers)
     echo "Got $output"
@@ -30,7 +30,7 @@ healthcheck(){
 
 cancel(){
     echo "[DEPLOY FAILED] Removing new color"
-    
+
     kubectl delete deployment $DEPLOYMENT_NAME-$NEW_VERSION --namespace=${NAMESPACE}
 
     exit 1
@@ -38,18 +38,18 @@ cancel(){
 
 
 mainloop(){
-   
+
     echo "[DEPLOY INFO] Selecting Kubernetes cluster"
     kubectl config use-context "${KUBE_CONTEXT}"
 
     echo "[DEPLOY INFO] Locating current version"
-    CURRENT_VERSION=$(kubectl get service $SERVICE_NAME -o=jsonpath='{.spec.selector.version}' --namespace=${NAMESPACE}) 
+    CURRENT_VERSION=$(kubectl get service $SERVICE_NAME -o=jsonpath='{.spec.selector.version}' --namespace=${NAMESPACE})
 
     if [ "$CURRENT_VERSION" == "$NEW_VERSION" ]; then
        echo "[DEPLOY NOP] NEW_VERSION is same as CURRENT_VERSION. Both are at $CURRENT_VERSION"
        exit 0
-    fi    
-    
+    fi
+
     echo "[DEPLOY NEW COLOR] Creating next version"
     kubectl get deployment $DEPLOYMENT_NAME-$CURRENT_VERSION -o=yaml --namespace=${NAMESPACE} | sed -e "s/$CURRENT_VERSION/$NEW_VERSION/g" | kubectl apply --namespace=${NAMESPACE} -f -
 
@@ -62,12 +62,12 @@ mainloop(){
     healthcheck
 
     echo "[DEPLOY SWITCH] Routing traffic to new color"
-    kubectl get service $SERVICE_NAME -o=yaml --namespace=${NAMESPACE} | sed -e "s/$CURRENT_VERSION/$NEW_VERSION/g" | kubectl apply --namespace=${NAMESPACE} -f - 
-     
+    kubectl get service $SERVICE_NAME -o=yaml --namespace=${NAMESPACE} | sed -e "s/$CURRENT_VERSION/$NEW_VERSION/g" | kubectl apply --namespace=${NAMESPACE} -f -
+
 
     echo "[DEPLOY CLEANUP] Removing previous color"
-    kubectl delete deployment $DEPLOYMENT_NAME-$CURRENT_VERSION --namespace=${NAMESPACE} 
-   
+    kubectl delete deployment $DEPLOYMENT_NAME-$CURRENT_VERSION --namespace=${NAMESPACE}
+
 }
 
 if [ "$1" != "" ] && [ "$2" != "" ] && [ "$3" != "" ] && [ "$4" != "" ] && [ "$5" != "" ] && [ "$6" != "" ]; then


### PR DESCRIPTION
- According to shellcheck rule [SC2028](https://github.com/koalaman/shellcheck/wiki/SC2028) the `echo` command does not expand escape sequences. So it would be better to use `printf` in bash script. Please check screenshot with output using `echo` and `printf`

echo
![echo](https://user-images.githubusercontent.com/4456572/70143607-c859d700-16a4-11ea-8e9b-3e3223a2c8ec.png)

printf
![printf](https://user-images.githubusercontent.com/4456572/70143541-9b0d2900-16a4-11ea-8854-a28b26e95da8.png)
`

- use current sh script name in `Usage` text
- remove whitespaces