### PR TITLE
Azure key vault saas 4694

### DIFF
--- a/incubating/azure-key-vault/Dockerfile
+++ b/incubating/azure-key-vault/Dockerfile
@@ -10,8 +10,8 @@ RUN apk update && \
         libffi-dev \openssl-dev \
         python3-dev && \
     pip install \
-        azure-common \
-        azure-keyvault
+        azure-identity \
+        'azure-keyvault-secrets==4.0.0'
 
 COPY lib/azure-key-vault.py /azure-key-vault.py
 

--- a/incubating/azure-key-vault/README.md
+++ b/incubating/azure-key-vault/README.md
@@ -1,7 +1,7 @@
 # cfstep-azure-key-vault
-Codefresh Pipeline Step for pulling secrets from Azure Key Vault
+Codefresh Pipeline Step for pulling secrets from Azure Key Vault and export them as environment variables for the next steps.
 
-You must create a Service Principal with a Secret to use this plugin.
+You must create a Service Principal with a Secret to use this plugin, and add the 'AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' as the pipeline variables or as the step arguments.
 
 https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-create-service-principals#manage-service-principal-for-azure-ad
 
@@ -12,8 +12,25 @@ You must grant the Service Principal `Get` permissions for `Keys` for the Key Va
 | ENVIRONMENT VARIABLE | DEFAULT | TYPE | REQUIRED | DESCRIPTION |
 |----------------------------|----------|---------|----------|---------------------------------------------------------------------------------------------------------------------------------|
 | AZURE_CLIENT_ID | null | string | Yes | Application (client) ID for Service Principal |
-| AZURE_SECRET | null | string | Yes | Secret for Service Principal |
-| AZURE_TENANT | null | string | Yes | Directory (tenant) ID for Service Principal|
-| AZURE_SECRET_ID | null | string | Yes | Secret ID from Azure Key Vault |
-| AZURE_SECRET_VERSION | null | string | Yes | Docker Registry Protocol |
-| AZURE_VAULT_URL | null | string | Yes | Secret Version from Azure Key Vault |
+| AZURE_CLIENT_SECRET | null | string | Yes | Client Secret for Service Principal |
+| AZURE_TENANT_ID | null | string | Yes | Directory (tenant) ID for Service Principal|
+| AZURE_VAUTL_NAME | null | string | Yes | Name of the Azure vault |
+| SECRETS | null | string | Yes | Comma separated list the secrets to get |
+
+## Limitations
+In order for secrets to be available as environment variables for the next steps, a freestyle step should be run to export new variables.
+```yaml
+version: '1.0'
+steps:
+  azure-key-vault:
+    type: azure-key-vault
+    arguments:
+      AZURE_VAULT_NAME: MY_VAULT_NAME
+      SECRETS:
+        - secret_1
+        - secret_2
+  export_vars:
+    image: 'alpine:latest'
+    commands:
+      - echo "Export vars"
+```

--- a/incubating/azure-key-vault/README.md
+++ b/incubating/azure-key-vault/README.md
@@ -16,21 +16,3 @@ You must grant the Service Principal `Get` permissions for `Keys` for the Key Va
 | AZURE_TENANT_ID | null | string | Yes | Directory (tenant) ID for Service Principal|
 | AZURE_VAUTL_NAME | null | string | Yes | Name of the Azure vault |
 | SECRETS | null | string | Yes | Comma separated list the secrets to get |
-
-## Limitations
-In order for secrets to be available as environment variables for the next steps, a freestyle step should be run to export new variables.
-```yaml
-version: '1.0'
-steps:
-  azure-key-vault:
-    type: azure-key-vault
-    arguments:
-      AZURE_VAULT_NAME: MY_VAULT_NAME
-      SECRETS:
-        - secret_1
-        - secret_2
-  export_vars:
-    image: 'alpine:latest'
-    commands:
-      - echo "Export vars"
-```

--- a/incubating/azure-key-vault/example.yml
+++ b/incubating/azure-key-vault/example.yml
@@ -1,12 +1,14 @@
 version: '1.0'
 steps:
+  steps:
   GetAzureSecret:
-    title: Fetching Azure Secret from Key Vault
-    image: codefreshplugins/cfstep-azure-key-vault:latest
-    environment:
-      - AZURE_CLIENT_ID=applicationid
-      - AZURE_SECRET=serviceprincipalsecret
-      - AZURE_TENANT=directoryid
-      - AZURE_SECRET_ID=mysecret
-      - AZURE_SECRET_VERSION=d9ccc49fadfe4f37b4039e7edd32aa41
-      - AZURE_VAULT_URL=https://dustinvb-kv.vault.azure.net/
+    type: azure-key-vault
+    arguments:
+      AZURE_VAULT_NAME: <MY_AZURE_VAULT_NAME>
+      SECRETS:
+        - secret1
+        - secret2
+        - secret3
+      AZURE_CLIENT_ID: ${{AZURE_CLIENT_ID}}
+      AZURE_CLIENT_SECRET: ${{AZURE_CLIENT_SECRET}}
+      AZURE_TENANT_ID: ${{AZURE_TENANT_ID}}

--- a/incubating/azure-key-vault/lib/azure-key-vault.py
+++ b/incubating/azure-key-vault/lib/azure-key-vault.py
@@ -1,39 +1,37 @@
-import json
 import os
 import sys
-import subprocess
-from azure.keyvault import KeyVaultClient
-from azure.common.credentials import ServicePrincipalCredentials
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
 
 
 def main():
-    client_id = os.getenv('AZURE_CLIENT_ID')
-    service_principal_secret = os.getenv('AZURE_SECRET')
-    tenant = os.getenv('AZURE_TENANT')
-    secret_id = os.getenv('AZURE_SECRET_ID')
-    secret_version = os.getenv('AZURE_SECRET_VERSION')
-    vault_url = os.getenv('AZURE_VAULT_URL')
+# To make default credentials work, ensure that environment variables 'AZURE_CLIENT_ID',
+# 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' are set with the service principal credentials
+  for azure_var in ['AZURE_CLIENT_ID','AZURE_CLIENT_SECRET','AZURE_TENANT_ID']:
+    if os.getenv(azure_var) is None:
+      print("The '{}' variable is not set".format(azure_var))
+      sys.exit(1)
 
-    # Get Service Principal Credentials
+  credential = DefaultAzureCredential()
 
-    credentials = ServicePrincipalCredentials(
-        client_id = client_id,
-        secret = service_principal_secret,
-        tenant = tenant
-    )
-    
-    # Auth with Service Principal
-    client = KeyVaultClient(credentials)
+  vault_name = os.getenv('AZURE_VAULT_NAME')
 
-    # Get Azure Secret from Azure Vault
-    # VAULT_URL must be in the format 'https://<vaultname>.vault.azure.net'
-    # SECRET_VERSION is required, and can be obtained with the KeyVaultClient.get_secret_versions(self, vault_url, secret_id) API
-    secret_bundle = client.get_secret(vault_url, secret_id, secret_version)
-    secret = secret_bundle.value
+  cf_volume_path = os.getenv('CF_VOLUME_PATH')
 
-    file_path = '/codefresh/volume/env_vars_to_export'
+  vault_url = "https://{}.vault.azure.net/".format(vault_name)
+
+  secret_client = SecretClient(vault_url=vault_url, credential=credential)
+
+  secrets = os.getenv('SECRETS').split(",")
+
+  for secret_name in secrets:
+    secret = secret_client.get_secret(secret_name)
+
+    print("Export '{}' secret".format(secret_name))
+    file_path = '{}/env_vars_to_export'.format(cf_volume_path)
     with open(file_path, 'a') as file:
-        file.write("{}={}\n".format(secret_id, secret))
+        file.write("{}={}\n".format(secret_name, secret.value))
+
 
 if __name__ == "__main__":
     main()

--- a/incubating/azure-key-vault/lib/azure-key-vault.py
+++ b/incubating/azure-key-vault/lib/azure-key-vault.py
@@ -16,20 +16,19 @@ def main():
 
   vault_name = os.getenv('AZURE_VAULT_NAME')
 
-  cf_volume_path = os.getenv('CF_VOLUME_PATH')
-
   vault_url = "https://{}.vault.azure.net/".format(vault_name)
 
   secret_client = SecretClient(vault_url=vault_url, credential=credential)
 
   secrets = os.getenv('SECRETS').split(",")
 
+  file_env_to_export_path = '/meta/env_vars_to_export'
+
   for secret_name in secrets:
     secret = secret_client.get_secret(secret_name)
 
-    print("Export '{}' secret".format(secret_name))
-    file_path = '{}/env_vars_to_export'.format(cf_volume_path)
-    with open(file_path, 'a') as file:
+    print("Exporting '{}' secret".format(secret_name))
+    with open(file_env_to_export_path, 'a') as file:
         file.write("{}={}\n".format(secret_name, secret.value))
 
 

--- a/incubating/azure-key-vault/step.yaml
+++ b/incubating/azure-key-vault/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: azure-key-vault
-  version: 0.0.3
+  version: 0.0.4
   isPublic: true
   description: Fetch Secrets from Azure Key Vault
   sources:
@@ -28,12 +28,38 @@ metadata:
           title: Fetching Azure Secret from Key Vault
           type: azure-key-vault
           arguments:
+            AZURE_VAULT_NAME: 'MY_AZURE_VAULT_NAME'
+            SECRETS:
+              - secret_1
+              - secret_2
+              - secret_3
+        export_vars:
+          image: alpine:latest
+          description: >-
+            In order for secrets to be available as environment variables for the next steps, any freestyle step should be run to export new variables.
+          commands:
+          - echo "Export vars"
+    - description: example-2
+      workflow:
+        GetAzureSecret:
+          title: Fetching Azure Secret from Key Vault
+          type: azure-key-vault
+          arguments:
+            AZURE_VAULT_NAME: 'MY_AZURE_VAULT_NAME'
+            SECRETS:
+              - secret_1
+              - secret_2
+              - secret_3
             AZURE_CLIENT_ID: ${{AZURE_CLIENT_ID}}
-            AZURE_SECRET: ${{AZURE_SECRET}}
-            AZURE_TENANT: ${{AZURE_TENANT}}
-            AZURE_SECRET_ID: ${{AZURE_SECRET_ID}}
-            AZURE_SECRET_VERSION: ${{AZURE_SECRET_VERSION}}
-            AZURE_VAULT_URL: ${{AZURE_VAULT_URL}}
+            AZURE_CLIENT_SECRET: ${{AZURE_CLIENT_SECRET}}
+            AZURE_TENANT_ID: ${{AZURE_TENANT_ID}}
+        export_vars:
+          image: alpine:latest
+          description: >-
+            In order for secrets to be available as environment variables for the next steps, any freestyle step should be run to export new variables.
+          commands:
+          - echo "Export vars"
+
 spec:
   arguments: |-
     {
@@ -42,31 +68,30 @@ spec:
         "type": "object",
         "additionalProperties": false,
         "patterns": [],
-        "required": [],
+        "required": ["AZURE_VAULT_NAME", "SECRETS"],
         "properties": {
             "AZURE_CLIENT_ID": {
                 "type": "string",
                 "description": "Application (client) ID for Service Principal"
             },
-            "AZURE_SECRET": {
+            "AZURE_CLIENT_SECRET": {
                 "type": "string",
                 "description": "Secret for Service Principal"
             },
-            "AZURE_TENANT": {
+            "AZURE_TENANT_ID": {
                 "type": "string",
                 "description": "Directory (tenant) ID for Service Principal"
             },
-            "AZURE_SECRET_ID": {
+            "AZURE_VAULT_NAME": {
                 "type": "string",
-                "description": "Secret ID from Azure Key Vault"
+                "description": "Name of the Azure vault"
             },
-            "AZURE_SECRET_VERSION": {
-                "type": "string",
-                "description": "Secret Version from Azure Key Vault"
-            },
-            "AZURE_VAULT_URL": {
-                "type": "string",
-                "description": "URL for Azure Key Vault"
+            "SECRETS": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of the secrets to get"
             }
         }
     }
@@ -75,9 +100,8 @@ spec:
       name: azure-key-vault
       image: codefreshplugins/cfstep-azure-key-vault
       environment:
-        - 'AZURE_CLIENT_ID=${{AZURE_CLIENT_ID}}'
-        - 'AZURE_SECRET=${{AZURE_SECRET}}'
-        - 'AZURE_TENANT=${{AZURE_TENANT}}'
-        - 'AZURE_SECRET_ID=${{AZURE_SECRET_ID}}'
-        - 'AZURE_SECRET_VERSION=${{AZURE_SECRET_VERSION}}'
-        - 'AZURE_VAULT_URL=${{AZURE_VAULT_URL}}'
+        - "AZURE_CLIENT_ID=${{AZURE_CLIENT_ID}}"
+        - "AZURE_CLIENT_SECRET=${{AZURE_CLIENT_SECRET}}"
+        - "AZURE_TENANT_ID=${{AZURE_TENANT_ID}}"
+        - "AZURE_VAULT_NAME=${{AZURE_VAULT_NAME}}"
+        - "SECRETS=${{SECRETS}}"

--- a/incubating/azure-key-vault/step.yaml
+++ b/incubating/azure-key-vault/step.yaml
@@ -33,12 +33,6 @@ metadata:
               - secret_1
               - secret_2
               - secret_3
-        export_vars:
-          image: alpine:latest
-          description: >-
-            In order for secrets to be available as environment variables for the next steps, any freestyle step should be run to export new variables.
-          commands:
-          - echo "Export vars"
     - description: example-2
       workflow:
         GetAzureSecret:
@@ -53,12 +47,6 @@ metadata:
             AZURE_CLIENT_ID: ${{AZURE_CLIENT_ID}}
             AZURE_CLIENT_SECRET: ${{AZURE_CLIENT_SECRET}}
             AZURE_TENANT_ID: ${{AZURE_TENANT_ID}}
-        export_vars:
-          image: alpine:latest
-          description: >-
-            In order for secrets to be available as environment variables for the next steps, any freestyle step should be run to export new variables.
-          commands:
-          - echo "Export vars"
 
 spec:
   arguments: |-


### PR DESCRIPTION
## Overview
- As the **azure-keyvault**  module was updated, the `KeyVaultClient` is not available more - [azure-sdk-for-python/issues/8591](https://github.com/Azure/azure-sdk-for-python/issues/8591), the new `SecretClient` is used instead.  
To login to the vault, the environment variables 'AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET' and 'AZURE_TENANT_ID' should be set. 
- Variable names, required to login, were updated in accordance with the default Azure variables names.
- Secrets to be imported, are sent as a comma-separated list.
- A version of a secret is not supported more. The latest version is used by default.
- To export secrets as environment variables for the next steps, a freestyle step should be run after the `azure-key-vault` step. 