### PR TITLE
Fix MSTEAMS_NEW_WEBHOOK_URL functionality

### DIFF
--- a/incubating/msteams-notifier/codefresh.yml
+++ b/incubating/msteams-notifier/codefresh.yml
@@ -15,7 +15,7 @@ steps:
     candidate: ${{BuildingDockerImage}}
     tags:
     - latest
-    - 0.1.0
+    - 0.1.1
     registry: dockerhub
     when:
       branch:

--- a/incubating/msteams-notifier/plugin.yml
+++ b/incubating/msteams-notifier/plugin.yml
@@ -1,7 +1,7 @@
 name: cfstep-msteams-notifier
 image: icon.jpg
-tag: 0.1.0
-version: 0.1.0
+tag: 0.1.1
+version: 0.1.1
 description: Send Message to Microsoft Teams
 categories:
 - notifications

--- a/incubating/msteams-notifier/script/pymsteams-notifier.py
+++ b/incubating/msteams-notifier/script/pymsteams-notifier.py
@@ -22,7 +22,7 @@ def main():
     msteams_link_text_2 = os.getenv('MSTEAMS_LINK_TEXT_2', 'Commit Information')
     msteams_link_url = os.getenv('MSTEAMS_LINK_URL', cf_build_url)
     msteams_link_url_2 = os.getenv('MSTEAMS_LINK_URL_2', cf_commit_url)
-    msteams_new_webhook_url = os.getenv('MSTEAMS_NEW_WEBHOOK_URL')
+    msteams_new_webhook_url = os.getenv('MSTEAMS_NEW_WEBHOOK_URL', None)
     msteams_text = os.getenv('MSTEAMS_TEXT', 'Codefresh Account: {}'.format(cf_account))
     msteams_title = os.getenv('MSTEAMS_TITLE', 'Codefresh Build Notification')
     msteams_webhook_url = os.getenv('MSTEAMS_WEBHOOK_URL')
@@ -72,7 +72,8 @@ def main():
     myTeamsMessage.addSection(myMessageSection)
 
     # Send to additional room
-    myTeamsMessage.newhookurl(msteams_new_webhook_url)
+    if msteams_new_webhook_url not None:
+        myTeamsMessage.newhookurl(msteams_new_webhook_url)
 
     myTeamsMessage.printme()
 

--- a/incubating/msteams-notifier/step.yaml
+++ b/incubating/msteams-notifier/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: msteams-notifier
-  version: 0.0.3
+  version: 0.0.4
   isPublic: true
   description: Send Message to Microsoft Teams
   sources:


### PR DESCRIPTION
Check if MSTEAMS_NEW_WEBHOOK_URL is included as environment variable and then include it in the msteams card creator.

Otherwise the whole step fails.

- [x] Bump Docker image version
- [x] Bump Codefresh step version
- [x] Bump Codefresh plugin.yml version