### PR TITLE
flip aws-parameter-store step to public

### DIFF
--- a/incubating/aws-parameter-store/step.yaml
+++ b/incubating/aws-parameter-store/step.yaml
@@ -3,7 +3,7 @@ version: '1.0'
 metadata:
   name: aws-parameter-store
   version: 0.0.3
-  isPublic: false
+  isPublic: true
   description: Gathers parameters from AWS Parameter Store
   sources:
     - >-


### PR DESCRIPTION
Switched aws-parameter-store step to be public.