### PR TITLE
recursive submodules fix

### DIFF
--- a/incubating/git-submodules/script/updategitsubmodules.sh
+++ b/incubating/git-submodules/script/updategitsubmodules.sh
@@ -1,27 +1,23 @@
 #!/bin/sh
+set -e
 
 if [ -z "$GITHUB_TOKEN" ]; then
     echo "ERROR: \$GITHUB_TOKEN var is not set or empty"
-    exit
+    exit 1
 fi
 
-mkdir ~/.ssh
-ssh-keyscan github.com > ~/.ssh/known_hosts
-sed -i 's/git@/https:\/\//' .gitmodules || exit
-sed -i 's/ssh:\/\///' .gitmodules
-sed -i 's/github.com:/github.com\//' .gitmodules
-sed -i "s/https:\/\/github.com/https:\/\/$GITHUB_TOKEN@github.com/" .gitmodules
+git config --global url.https://$GITHUB_TOKEN@github.com/.insteadOf git@github.com:
 
 if [ "$CF_SUBMODULE_SYNC" = "true" ]; then
-  echo "\$CF_SUBMODULE_SYNC var is set to 'true'. Syncing submodules"
-  echo "git submodule sync"
-  git submodule sync
+    echo "\$CF_SUBMODULE_SYNC var is set to 'true'. Syncing submodules"
+    echo "git submodule sync"
+    git submodule sync
 fi
 
 SUBMODULE_UPDATE_RECURSIVE_FLAG=""
 if [ "$CF_SUBMODULE_UPDATE_RECURSIVE" = "true" ]; then
-  echo "\$CF_SUBMODULE_UPDATE_RECURSIVE var is set to 'true'. Submodules will be recursively updated"
-  SUBMODULE_UPDATE_RECURSIVE_FLAG=--recursive
+    echo "\$CF_SUBMODULE_UPDATE_RECURSIVE var is set to 'true'. Submodules will be recursively updated"
+    SUBMODULE_UPDATE_RECURSIVE_FLAG=--recursive
 fi
 
 echo "Updating git submodules"


### PR DESCRIPTION
this PR for git-submodules step:

1. sets correct exit status for failed steps
2. fixes recursive submodules, replacing the `sed` hack with `git config` (`sed` hack didn't work for recursive submodules, so the step didn't work)
3. cleans up the code