### PR TITLE
Sa 54 publish k8s canary step

### DIFF
--- a/incubating/k8s-canary-deployment/Dockerfile
+++ b/incubating/k8s-canary-deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM codefresh/kube-helm:master
+FROM codefresh/kube-helm:latest
 
 RUN mkdir /app
 

--- a/incubating/k8s-canary-deployment/codefresh.yml
+++ b/incubating/k8s-canary-deployment/codefresh.yml
@@ -3,6 +3,14 @@ steps:
   BuildingDockerImage:
     title: Building Docker Image
     type: build
-    image_name: codefreshplugins/k8s-canary
+    image_name: codefreshplugins/k8s-canary-deployment
     tag: ${{CF_BRANCH}}
     dockerfile: Dockerfile
+  PushingDockerImage:
+    type: push
+    candidate: ${{BuildingDockerImage}}
+    tag: "latest"
+    when:
+      branch:
+        only:
+          - master

--- a/incubating/k8s-canary-deployment/example.yml
+++ b/incubating/k8s-canary-deployment/example.yml
@@ -9,7 +9,7 @@ steps:
     dockerfile: Dockerfile
   canaryDeploy:
     title: "Deploying new version ${{CF_SHORT_REVISION}}"
-    image: codefreshplugins/k8s-canary
+    image: codefreshplugins/k8s-canary-deployment:latest
     environment:
       - WORKING_VOLUME=.
       - SERVICE_NAME=my-demo-app

--- a/incubating/k8s-canary-deployment/example/codefresh.yml
+++ b/incubating/k8s-canary-deployment/example/codefresh.yml
@@ -9,7 +9,7 @@ steps:
     dockerfile: Dockerfile
   canaryDeploy:
     title: "Deploying new version ${{CF_SHORT_REVISION}}"
-    image: codefreshplugins/k8s-canary
+    image: codefreshplugins/k8s-canary-deployment
     environment:
       - WORKING_VOLUME=.
       - SERVICE_NAME=my-demo-app

--- a/incubating/k8s-canary-deployment/plugin.yml
+++ b/incubating/k8s-canary-deployment/plugin.yml
@@ -1,5 +1,5 @@
 name: k8s-canary-deployment
-image: codefreshplugins/k8s-canary
+image: codefreshplugins/k8s-canary-deployment:latest
 tag: 0.1.0
 version: 0.1.0
 description: Perform a gradual canary deployment using only Kuberentes manifests.

--- a/incubating/k8s-canary-deployment/step.yaml
+++ b/incubating/k8s-canary-deployment/step.yaml
@@ -1,11 +1,11 @@
 kind: step-type
 version: '1.0'
 metadata:
-  name: k8s-canary-deployment
-  version: 0.0.4
+  name: codefreshdemo/k8s-canary-deployment
+  version: 0.0.5
   title: Canary deployment for plain K8s
   isPublic: false
-  description: Perform a gradual canary deployment using only Kuberentes manifests.
+  description: Perform a gradual canary deployment using only Kubernetes manifests.
   sources:
     - >-
       https://github.com/codefresh-io/steps/tree/master/incubating/k8s-canary-deployment
@@ -13,6 +13,8 @@ metadata:
   maintainers:
     - name: Kostis Kapelonis
       email: support@codefresh.io
+    - name: Dustin Van Buskirk
+      email: dustin@codefresh.io
   categories:
     - featured
     - deployment
@@ -34,9 +36,9 @@ metadata:
             WORKING_VOLUME: ${{WORKING_VOLUME}}
             SERVICE_NAME: ${{SERVICE_NAME}}
             DEPLOYMENT_NAME: ${{DEPLOYMENT_NAME}}
-            TRAFFIC_INCREMENT: ${{TRAFFIC_INCREMENT}}
-            NEW_VERSION: ${{NEW_VERSION}}
-            SLEEP_SECONDS: ${{SLEEP_SECONDS}}
+            TRAFFIC_INCREMENT: '${{TRAFFIC_INCREMENT}}'
+            NEW_VERSION: '${{NEW_VERSION}}'
+            SLEEP_SECONDS: '${{SLEEP_SECONDS}}'
             NAMESPACE: ${{NAMESPACE}}
             KUBE_CONTEXT: ${{KUBE_CONTEXT}}
 spec:
@@ -55,7 +57,7 @@ spec:
             },
             "NAMESPACE": {
                 "type": "string",
-                "description": "The name of the kubenretes namespace"
+                "description": "The name of the kubernetes namespace"
             },
             "TRAFFIC_INCREMENT": {
                 "type": "string"

--- a/incubating/k8s-canary-deployment/step.yaml
+++ b/incubating/k8s-canary-deployment/step.yaml
@@ -1,10 +1,10 @@
 kind: step-type
 version: '1.0'
 metadata:
-  name: codefreshdemo/k8s-canary-deployment
+  name: k8s-canary-deployment
   version: 0.0.5
   title: Canary deployment for plain K8s
-  isPublic: false
+  isPublic: true
   description: Perform a gradual canary deployment using only Kubernetes manifests.
   sources:
     - >-
@@ -13,8 +13,6 @@ metadata:
   maintainers:
     - name: Kostis Kapelonis
       email: support@codefresh.io
-    - name: Dustin Van Buskirk
-      email: dustin@codefresh.io
   categories:
     - featured
     - deployment
@@ -87,7 +85,7 @@ spec:
   steps:
     main:
       name: k8s-canary-deployment
-      image: codefreshplugins/k8s-canary
+      image: codefreshplugins/k8s-canary-deployment:latest
       environment:
         - WORKING_VOLUME=${{WORKING_VOLUME}}
         - SERVICE_NAME=${{SERVICE_NAME}}


### PR DESCRIPTION
Canary is fixed by updating kubectl
This pushes the step public as well