### PR TITLE
added example for repos argument

### DIFF
--- a/graduated/helm/step.yaml
+++ b/graduated/helm/step.yaml
@@ -54,6 +54,9 @@ metadata:
               custom_values:
                 - pat.arr="{one,two,three}"
                 - STR_WITH_COMAS="one\,two\,three"
+              repos:
+                - name: stable
+                  url: https://kubernetes-charts.storage.googleapis.com/
     - description: example-push
       workflow:
           deploy:


### PR DESCRIPTION
Added an example for "repos" argument to the helm step documentation, because the accepted syntax for this argument is not intuitive to users.