### PR TITLE
Update argocd-sync steps

### DIFF
--- a/graduated/argocd-sync/step.yaml
+++ b/graduated/argocd-sync/step.yaml
@@ -2,7 +2,7 @@ version: '1.0'
 kind: step-type
 metadata:
   name: argocd-sync
-  version: 1.7.1
+  version: 1.7.2
   isPublic: true
   description: This pipeline plugin trigger a sync for ArgoCD app
   sources:
@@ -95,7 +95,10 @@ spec:
               "default": ""
           },
           "additional_flags": {
-              "type": "string",
+              "type": ["string","array"],
+              "items": {
+                  "type": "string"
+              },
               "description": "Additional flags for argocd command ( like --grpc-web, so on )",
               "default": ""
           },
@@ -126,13 +129,13 @@ spec:
         - chmod +x /codefresh/volume/argo-executor
         - chmod +x /codefresh/volume/argo-export_url
         - /codefresh/volume/argo-export_url
+        - export ARGOCD_OPTS=$(echo ${{additional_flags}} | tr "," " ")
+        - echo ARGOCD_OPTS=$ARGOCD_OPTS >> /meta/env_vars_to_export
     executeArgoCd:
       title: "ExecuteArgoCd"
       image: "codefresh/cf-argo-plugin:0.0.8"
       commands:
         - /codefresh/volume/argo-executor
-      environment:
-        - ARGOCD_OPTS=${{additional_flags}}
     sendArgoMetadata:
       title: "SendArgoMetadata"
       fail_fast: false


### PR DESCRIPTION
## Overview
Added possibility to pass the `additional_flags`  either a string or a list of strings. 

Both options should work:
1. 
```yaml
  sync_and_wait_with_flags:
    title: Sync ArgoCD app and wait
     type: argocd-sync
    arguments:
      debug: true
      context: dev-mgmt
      app_name: staging
      additional_flags: --insecure --loglevel debug --timeout 1200 --grpc-web --grpc-web-root-path /argocd 
```

2. 
```yaml
  sync_and_wait_with_flags:
    title: Sync ArgoCD app and wait
     type: argocd-sync
    arguments:
      debug: true
      context: dev-mgmt
      app_name: staging
      additional_flags:
        - --insecure 
        - --loglevel debug
        - --timeout 1100 
        - --grpc-web 
        - --grpc-web-root-path /argocd 
```