### PR TITLE
Update git-commit description

### DIFF
--- a/incubating/git-commit/step.yaml
+++ b/incubating/git-commit/step.yaml
@@ -57,7 +57,7 @@ spec:
           },
           "git": {
               "type": "string",
-              "description": "The name of the git integration (non-OAuth2) you want to use. Oauth2 compatibility is coming soon. If left empty, Codefresh will attempt to use the git provider that was used during account sign-up. Note that this might have unexpected results if you are changing your Git integrations."
+              "description": "The name of the git integration you want to use. If left empty, Codefresh will attempt to use the git provider that was used during account sign-up. Note that this might have unexpected results if you are changing your Git integrations."
           },
           "commit_message": {
               "type": "string",


### PR DESCRIPTION
Removed comment about OAuth2 not working in description of the git argument.
This was found to not be an issue with the step, but an issue with the
GitHub provider. Workaround: enable "Allow access to private repositories"
option in the GitHub integration, even if the target repo is public.