### PR TITLE
Increment git-commit version

### DIFF
--- a/incubating/git-commit/step.yaml
+++ b/incubating/git-commit/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: git-commit
-  version: 0.0.10
+  version: 0.0.11
   isPublic: true
   description: Commit and push changes to repository
   icon:


### PR DESCRIPTION
Increment the step version of git-commit to 0.0.11 so that the updated step Description in https://github.com/codefresh-io/steps/pull/224 will take effect.