### PR TITLE
Add FOLLOW_LOGS argument to codefresh-run

### DIFF
--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: codefresh-run
   title: Run a Codefresh pipeline
-  version: 1.0.8
+  version: 1.0.9
   isPublic: true
   description: Run a Codefresh pipeline by ID or name and attach the created build logs.
   sources:

--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -97,6 +97,11 @@ spec:
                 "description": "Run pipeline and print build ID",
                 "default": false
             },
+            "FOLLOW_LOGS": {
+                "type": "boolean",
+                "description": "Follow the pipeline's logs (if not detached)",
+                "default": true
+            },
             "CONTEXT": {
                 "type": "array",
                 "items": {
@@ -189,8 +194,10 @@ spec:
       image: codefresh/cli
       commands:
         - export BUILD_ID=${{steps.first.output.BUILD_ID}}
+        [[- if eq .Arguments.FOLLOW_LOGS true ]]
         - echo "Retrieving logs for build $BUILD_ID"
         - codefresh logs -f $BUILD_ID
+        [[- end ]]
         - codefresh wait $BUILD_ID
       [[- end -]]
 

--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -78,61 +78,61 @@ spec:
                 "default": false
             },
             "NO_CF_CACHE": {
-                   "type": "boolean",
-                   "description": "Ignore Codefresh cache optimizations",
-                   "default": false
-               },
+                "type": "boolean",
+                "description": "Ignore Codefresh cache optimizations",
+                "default": false
+            },
             "ENABLE_NOTIFICATIONS": {
                 "type": "boolean",
                 "description": "Report notifications about pipeline execution",
                 "default": false
             },
             "RESET_VOLUME": {
-                  "type": "boolean",
-                  "description": "Reset pipeline cached volume",
-                  "default": false
+                "type": "boolean",
+                "description": "Reset pipeline cached volume",
+                "default": false
             },
             "DETACH": {
-                 "type": "boolean",
-                 "description": "Run pipeline and print build ID",
-                 "default": false
-             },
+                "type": "boolean",
+                "description": "Run pipeline and print build ID",
+                "default": false
+            },
             "CONTEXT": {
-                 "type": "array",
-                 "items": {
-                     "type": "string"
-                 },
-                 "description": "Run pipeline with contexts",
-                 "examples": ["git-context-1"],
-                 "default": []
-             },
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Run pipeline with contexts",
+                "examples": ["git-context-1"],
+                "default": []
+            },
             "VARIABLE": {
-                 "type": "array",
-                 "items": {
-                     "type": "string"
-                 },
-                 "description": "Set build variables",
-                 "examples": ["key=val"],
-                 "default": []
-             },
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Set build variables",
+                "examples": ["key=val"],
+                "default": []
+            },
             "ONLY": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
-                  },
-                  "description": "run only specifc steps",
-                  "examples": ["step1", "step2"],
-                  "default": []
-              },
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "run only specifc steps",
+                "examples": ["step1", "step2"],
+                "default": []
+            },
             "SKIP": {
-                  "type": "array",
-                  "items": {
-                      "type": "string"
-                  },
-                  "description": "skip specifc steps",
-                  "examples": ["step1", "step2"],
-                  "default": []
-              }
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "skip specifc steps",
+                "examples": ["step1", "step2"],
+                "default": []
+            }
         }
     }
   delimiters:


### PR DESCRIPTION
If a downstream/triggered pipeline produces a large amount of logs, it can overwhelm the parent pipeline. This change allows a pipeline to be triggered and remain attached without overwhelming the parent pipeline's logs.