### PR TITLE
Add FOLLOW_LOGS argument to codefresh-run

### DIFF
--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: codefresh-run
   title: Run a Codefresh pipeline
-  version: 1.1.0
+  version: 1.2.0
   isPublic: true
   description: Run a Codefresh pipeline by ID or name and attach the created build logs.
   sources:
@@ -97,6 +97,11 @@ spec:
                  "description": "Run pipeline and print build ID",
                  "default": false
              },
+            "FOLLOW_LOGS": {
+                "type": "boolean",
+                "description": "Follow the pipeline's logs (if attached)",
+                "default": true
+            },
             "CONTEXT": {
                  "type": "array",
                  "items": {
@@ -189,8 +194,12 @@ spec:
       image: quay.io/codefresh/cli
       commands:
         - export BUILD_ID=${{steps.first.output.BUILD_ID}}
+        [[- if .Arguments.FOLLOW_LOGS ]]
         - echo "Retrieving logs for build $BUILD_ID"
-        - codefresh logs -f $BUILD_ID
+        [[- else ]]
+        - /bin/sh -c 'while sleep 600; do echo "Waiting for pipeline to finish..."; done &'
+        [[- end ]]
+        - 'codefresh logs -f $BUILD_ID [[- if not .Arguments.FOLLOW_LOGS ]] &> /dev/null [[- end ]]'
         - codefresh wait $BUILD_ID
       [[- end -]]
 


### PR DESCRIPTION
When a pipeline that generates a large amount of logs is run, the parent pipeline can be overrun with logs. All logs from the pipeline are contained in a single step's output, slowing down the UI.

This change allows a pipeline to be run without following the logs, thus avoiding overwhelming the parent pipeline with logs.

----

Two caveats apply to this change:
1. There still needs to be some output, so a periodic output is included
2. Without the `codefresh logs` call, `codefresh wait` sometimes waits a significant amount of time after the pipeline has finished before returning. Instead, we simply pipe the logs to /dev/null.