### PR TITLE
Moving jfrog-cli to quay

### DIFF
--- a/incubating/jfrog-cli/step.yaml
+++ b/incubating/jfrog-cli/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: jfrog-cli
-  version: 0.0.8
+  version: 0.0.9
   isPublic: true
   description: Publishes artifacts to a Build in Artifactory. Also allows you to run additional Jfrog CLI commands during the publishing.
   sources:
@@ -154,12 +154,12 @@ spec:
         "JFROG_CLI_IMAGE": {
           "type": "string",
           "description": "The Docker image registry/image for step.",
-          "default": "codefreshplugins/cfstep-jfrog-cli"
+          "default": "quay.io/codefreshplugins/cfstep-jfrog-cli"
         },
         "JFROG_CLI_IMAGE_TAG": {
           "type": "string",
           "description": "The Docker image tag for step.",
-          "default": "0.0.8"
+          "default": "0.0.9"
         },
         "GRADLE_DEPLOY_REPO": {
           "type": "string",


### PR DESCRIPTION
quay.io/codefreshplugins/cfstep-jfrog-cli needs to be made `public` (quay repos are private by default)