### PR TITLE
Fixed typo from quey.io to quay.io

### DIFF
--- a/incubating/healthcheck/step.yaml
+++ b/incubating/healthcheck/step.yaml
@@ -170,7 +170,7 @@ spec:
   stepsTemplate: |-
     main:
       name: healthcheck
-      image: quey.io/codefreshplugins/cfstep-healthcheck:1.1.7
+      image: quay.io/codefreshplugins/cfstep-healthcheck:1.1.6
       environment:
       [[ range $key, $val := .Arguments ]]
         - '[[ $key ]]=[[ $val ]]'


### PR DESCRIPTION
Fixed typo from quey.io to quay.io. Also bumped image version down to 1.1.6 as 1.1.7 doesn't actually exist in registry