### PR TITLE
Adding SONAR_SCANNER_OPTS

### DIFF
--- a/incubating/sonar-scanner-cli/step.yaml
+++ b/incubating/sonar-scanner-cli/step.yaml
@@ -90,6 +90,11 @@ spec:
         "SONAR_ANALYSIS_PARAMETERS": {
           "type": "array",
           "description": "Array of additional Sonarqube Analysis Parameters Ex. - sonar.projectDescription='mycustomdescription'. List: https://docs.sonarqube.org/latest/analysis/analysis-parameters/"
+        },
+        "SONAR_SCANNER_OPTS": {
+          "type": "string",
+          "default": "-Xmx2048m",
+          "description": "Default jvm memory setting for the Sonar process."
         }
       }
     }

--- a/incubating/sonar-scanner-cli/step.yaml
+++ b/incubating/sonar-scanner-cli/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: sonar-scanner-cli
-  version: 1.0.0
+  version: 1.0.1
   isPublic: true
   description: Invokes scan using Sonarqube, step is not compatible with C/C++/Objective-C projects.  Requires sonar-project.properties file with Project Name and Key defined.  Documentation - https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/
   sources:


### PR DESCRIPTION
We found 2048m to be a good small size, but it should be overridden as teams see fit.