### PR TITLE
Support Kanban project type (no 'components' field)

### DIFF
--- a/incubating/jira-issue-manager/step.yaml
+++ b/incubating/jira-issue-manager/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: jira-issue-manager
-  version: 1.0.6
+  version: 1.0.7
   title: Jira Issue Manager
   isPublic: true
   description: Create, Update, & Validate Jira Issues
@@ -243,7 +243,7 @@ spec:
   stepsTemplate: |-
     main:
         name: jira-issue-manager
-        image: quay.io/codefreshplugins/jira-issue-manager:1.0.6
+        image: quay.io/codefreshplugins/jira-issue-manager:1.0.7
         environment:
         [[ range $key, $val := .Arguments ]]
           - '[[ $key ]]=[[ $val ]]'


### PR DESCRIPTION
Add components to the dict iff they are set. Kanban project issues don't have components, so the step errors if they are set in the request

Tests in `codefreshdemo`: 
 - classic style project - https://g.codefresh.io/build/618935b8d4281b2123d0d1d6
 - kanban style project - https://g.codefresh.io/build/6189314d8da189a7bdb4f759