### PR TITLE
remove message assert as it fails when using interpolation and add SLACK_ATTACHMENTS

### DIFF
--- a/incubating/slack-post-channel/lib/slack.py
+++ b/incubating/slack-post-channel/lib/slack.py
@@ -42,7 +42,6 @@ def main():
 
     try:
         response = client.chat_postMessage(channel=channel, text=message)
-        assert response["message"]["text"] == message
     except SlackApiError as e:
         # You will get a SlackApiError if "ok" is False
         assert e.response["ok"] is False

--- a/incubating/slack-post-channel/lib/slack.py
+++ b/incubating/slack-post-channel/lib/slack.py
@@ -6,6 +6,7 @@ Script to send a message to a named Slack channel
 import os
 import sys
 import logging
+import json
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
@@ -13,9 +14,10 @@ def main():
     log_format = "%(asctime)s:%(levelname)s:%(name)s.%(funcName)s: %(message)s"
     logging.basicConfig(format = log_format, level = os.environ['LOG_LEVEL'].upper())
 
-    channel=os.getenv('SLACK_CHANNEL')
-    message=os.getenv('SLACK_MESSAGE', "")
-    token  =os.getenv('SLACK_TOKEN')
+    channel     =os.getenv('SLACK_CHANNEL')
+    message     =os.getenv('SLACK_MESSAGE', "")
+    token       =os.getenv('SLACK_TOKEN')
+    attachments =os.getenv('SLACK_ATTACHMENTS', "")
 
     if ( channel == None ):
         logging.error("SLACK_CHANNEL is not defined")
@@ -24,6 +26,13 @@ def main():
     if ( token == None ):
         logging.error("SLACK_TOKEN is not defined")
         sys.exit(1)
+
+    if ( attachments != "" ):
+        try:
+            attachments = json.loads(attachments)
+        except ValueError as e:
+            logging.error(f"Error decoding attachments: {e}")
+            sys.exit(3)
 
     logging.info("Connecting to Slack")
     client = WebClient(token=token)
@@ -41,7 +50,7 @@ def main():
             sys.exit(3)
 
     try:
-        response = client.chat_postMessage(channel=channel, text=message)
+        response = client.chat_postMessage(channel=channel, text=message, attachments=attachments)
     except SlackApiError as e:
         # You will get a SlackApiError if "ok" is False
         assert e.response["ok"] is False

--- a/incubating/slack-post-channel/step.yaml
+++ b/incubating/slack-post-channel/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: slack-post-channel
-  version: 0.0.6
+  version: 0.0.7
   title: Send a Slack message to a channel
   isPublic: true
   description: Send a message to a named Slack channel (instead of using a webhook URL)
@@ -66,6 +66,11 @@ spec:
                 "type": "string",
                 "description": "The message to send to the channel. Use <@ID> to tag a user. Check https://api.slack.com/reference/surfaces/formatting for details.",
                 "default": "Message sent from Codefresh was not defined explicitely."
+            },
+            "SLACK_ATTACHMENTS": {
+                "type": "string",
+                "description": "Attachments to send. Documentation https://api.slack.com/docs/message-attachments",
+                "default": ""
             },
             "LOG_LEVEL": {
               "type": "string",

--- a/incubating/slack-post-channel/step.yaml
+++ b/incubating/slack-post-channel/step.yaml
@@ -51,7 +51,7 @@ spec:
             },
             "SLACK_IMAGE_VERSION": {
               "type": "string",
-              "default": "0.0.6",
+              "default": "0.0.7",
               "description": "Version (tag) of the slack-post-channel image to use."
             },
             "SLACK_TOKEN": {


### PR DESCRIPTION
* remove the message assert as it fails when using interpolation, eg message:
```
SLACK_MESSAGE: "External API ${{CF_BRANCH}} release completed: g.codefresh.io/build/${{CF_BUILD_ID}}"
```

* Add `SLACK_ATTACHMENTS` variable