### PR TITLE
Respect the current branch when pulling during git-commit step

### DIFF
--- a/incubating/git-commit/step.yaml
+++ b/incubating/git-commit/step.yaml
@@ -182,7 +182,7 @@ spec:
         - git status
         - |-
           if [ "$REBASE" = true ]; then
-            git pull --rebase "https://$GIT_ACCESS_TOKEN_USER:$GIT_ACCESS_TOKEN@$GIT_FQDN/$REPO.git"
+            git pull --rebase "https://$GIT_ACCESS_TOKEN_USER:$GIT_ACCESS_TOKEN@$GIT_FQDN/$REPO.git $CF_BRANCH"
           fi
         - echo git push "https://$GIT_ACCESS_TOKEN_USER:REDACTED@$GIT_FQDN/$REPO.git"
         - |-


### PR DESCRIPTION
Currently during the git-commit step when enabling the option `rebase: true` the git pull --rebase` command just pulls from the specified remote repository. So if your CodeFresh pipeline is running on a specific branch it will pull from the default rather than from your current branch. This will also cause the git push afterwards to fail.