### PR TITLE
feat(codefresh-run): add `TERMINATE_ON_TIMEOUT` argument

### DIFF
--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -146,7 +146,7 @@ spec:
             },
             "TERMINATE_ON_TIMEOUT": {
                 "type": "boolean",
-                "description": "Terminate child build if timeout expired",
+                "description": "Terminate build if timeout reached",
                 "default": false
             },
             "ONLY": {

--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: codefresh-run
   title: Run a Codefresh pipeline
-  version: 1.2.6
+  version: 1.3.0
   isPublic: true
   description: Run a Codefresh pipeline by ID or name and attach the created build logs.
   sources:
@@ -144,6 +144,11 @@ spec:
                 "examples": ["33.3", "45"],
                 "default": "45"
             },
+            "TERMINATE_ON_TIMEOUT": {
+                "type": "boolean",
+                "description": "Terminate child build if timeout expired",
+                "default": false
+            },
             "ONLY": {
                   "type": "array",
                   "items": {
@@ -228,6 +233,11 @@ spec:
         - echo "Retrieving logs for build $BUILD_ID"
         - codefresh logs -f --no-timestamps $BUILD_ID
       [[- end ]]
-        - codefresh wait --verbose $BUILD_ID --timeout [[(printf "%s"  .Arguments.TIMEOUT_MINS)]]
+        - >-
+          codefresh wait --verbose $BUILD_ID --timeout [[(printf "%s"  .Arguments.TIMEOUT_MINS)]]
+      [[- if eq .Arguments.TERMINATE_ON_TIMEOUT true ]]
+          || (echo "TERMINATE_ON_TIMEOUT was set to true, sending termination request" &&
+              codefresh terminate $BUILD_ID &&
+              exit 1)
+      [[- end ]]
       [[- end -]]
-


### PR DESCRIPTION
## Overview

This adds a new argument to `codefresh-run` step: `TERMINATE_ON_TIMEOUT`.
If set to `true` and timeout from `TIMEOUT_MINS` is expired, child build will be terminated.

## Backward compatibility
New argument defaults to `false` if not passed. If `false`, previous behavior is untouched.
This guarantees unchanged behavior for any previously implemented flow with this step.

Closes [#CR-16035](https://codefresh-io.atlassian.net/browse/CR-16035)