### PR TITLE
feat(codefresh-run): add `PACK_NAME` argument

### DIFF
--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: codefresh-run
   title: Run a Codefresh pipeline
-  version: 1.3.1
+  version: 1.4.0
   isPublic: true
   description: Run a Codefresh pipeline by ID or name and attach the created build logs.
   sources:
@@ -104,6 +104,11 @@ spec:
                 "examples": ["my-runtime-name"],
                 "default": ""
             },
+            "PACK_NAME": {
+                "type": "string",
+                "description": "Resources size (small, medium or large).",
+                "default": ""
+            },
             "DETACH": {
                  "type": "boolean",
                  "description": "Run pipeline without assigning to a project and print build ID.",
@@ -200,6 +205,9 @@ spec:
         [[- end -]]
         [[ if .Arguments.RUNTIME_NAME ]]
             [[- $cmd = (printf "%s --runtime-name %s" $cmd .Arguments.RUNTIME_NAME) -]]
+        [[- end -]]    
+        [[ if .Arguments.PACK_NAME ]]
+            [[- $cmd = (printf "%s --pack-name %s" $cmd .Arguments.PACK_NAME) -]]
         [[- end -]]    
         [[ range .Arguments.VARIABLE ]]
             [[- $cmd = (printf "%s --variable %s" $cmd .) -]]


### PR DESCRIPTION
## Overview

`PACK_NAME` argument allows to choose resources size. Allowed values are inherited from `codefresh run --pack-name=<value>`; check [Codefresh CLI documentation](https://codefresh-io.github.io/cli/pipelines/run-pipeline/) for more details.

Usage example:
```yaml
version: "1.0"
steps:
  run_pipeline:
    type: codefresh-run
    title: Run child pipeline
    arguments:
      PIPELINE_ID: project/pipeline
      PACK_NAME: medium

```

## Backward compatibility

The new argument defaults to empty string if not passed. If empty, previous behavior is untouched.
This guarantees unchanged behavior for any previously implemented flow with this step.

Closes #CR-17123