### PR TITLE
feat(codefresh-run): add `YAML` argument

### DIFF
--- a/graduated/codefresh-run/step.yaml
+++ b/graduated/codefresh-run/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: codefresh-run
   title: Run a Codefresh pipeline
-  version: 1.4.0
+  version: 1.5.0
   isPublic: true
   description: Run a Codefresh pipeline by ID or name and attach the created build logs.
   sources:
@@ -171,7 +171,12 @@ spec:
                   "description": "Skip the specifc steps defined.",
                   "examples": ["step1", "step2"],
                   "default": []
-              }
+            },
+            "YAML": {
+                "type": "string",
+                "description": "Path to pipeline's yaml to be used as override for this execution.",
+                "default": ""
+            }
         }
     }
   delimiters:
@@ -224,11 +229,15 @@ spec:
         [[ range .Arguments.SKIP ]]
             [[- $cmd = (printf "%s --skip %s" $cmd .) -]]
         [[- end ]]
+        [[ if .Arguments.YAML ]]
+            [[- $cmd = (printf "%s --yaml %s" $cmd .Arguments.YAML) -]]
+        [[- end -]]   
 
         [[/* Multiline string is required to support usage of 'colon' (:) character in the string. For example in the pipeline name. */]]
         [[/* Otherwise after template render there is a chance to have an object instead of a string. */]]
           - >-
-            export BUILD_ID=$([[ $cmd ]]); if [ -z "$BUILD_ID" ]; then exit 1; fi
+            CLI_OUTPUT=$([[ $cmd ]]) &&
+            export BUILD_ID=$(echo "$CLI_OUTPUT" | tail -n 1); if [ -z "$BUILD_ID" ]; then exit 1; fi
           - cf_export first_CF_OUTPUT_URL="${{CF_URL}}/build/$BUILD_ID"
           - cf_export BUILD_ID
       [[- if eq .Arguments.DETACH false ]]


### PR DESCRIPTION
## Overview

`YAML` argument allows to change pipeline's yaml on the fly for this execution. Its behavior is inherited from the `--yaml` option of the CLI. Please check [CLI docs](https://codefresh-io.github.io/cli/pipelines/run-pipeline/#options) for details.

## Backward compatibility

The new argument defaults to empty string if not passed. If empty, previous behavior is untouched.

Closes #CR-14668