### PR TITLE
Remove REPO_URL echo from git-commit step

### DIFF
--- a/incubating/git-commit/step.yaml
+++ b/incubating/git-commit/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: git-commit
-  version: 0.1.0
+  version: 0.1.1
   isPublic: true
   description: Commit and push changes to repository
   icon:

--- a/incubating/git-commit/step.yaml
+++ b/incubating/git-commit/step.yaml
@@ -213,7 +213,6 @@ spec:
           if [ "$REBASE" = true ]; then
             git pull --rebase $REPO_URL
           fi
-        - echo git push $REPO_URL
         - |-
           if [ "$FORCE_PUSH" = true ]; then
             git push --force $REPO_URL


### PR DESCRIPTION
Currently, the `git-commit` step is [echo's](https://github.com/codefresh-io/steps/blob/08e1800259cf3d37bff19256d986168202b63482/incubating/git-commit/step.yaml#L216) the `REPO_URL` which exposes the Git Access token is HTTPS is used. This PR is to remove the `echo` command. 


Closes #557 