### PR TITLE
PR: Trivy Scanner v0.0.4 - Upgraded to LTS 0.41.0 and Fixed Null Iteration and Skip Empty Report Bugs

### DIFF
--- a/incubating/trivy/Dockerfile
+++ b/incubating/trivy/Dockerfile
@@ -1,4 +1,4 @@
-FROM aquasec/trivy:latest
+FROM aquasec/trivy:0.41.0
 
 ADD entrypoint.sh /usr/local/bin
 

--- a/incubating/trivy/entrypoint.sh
+++ b/incubating/trivy/entrypoint.sh
@@ -19,9 +19,9 @@ function echoSection {
 
 unset_empty_vars() {
   echoSection "Unsetting empty vars"
-  for var in $(env); do 
-    if [[ "${var##*=}" == "\${{${var%=*}}}" ]]; then 
-      echo "Unsetting ${var%=*}"; 
+  for var in $(env); do
+    if [[ "${var##*=}" == "\${{${var%=*}}}" ]]; then
+      echo "Unsetting ${var%=*}";
       unset ${var%=*};
     fi;
   done
@@ -34,8 +34,8 @@ set_trivy_ignore() {
   if [[ ! -z $TRIVY_IGNORE_FILE ]]; then
     stat -c "%n" "$TRIVY_IGNORE_FILE"
     cp $TRIVY_IGNORE_FILE $TRIVY_IGNOREFILE
-  fi 
-  local IFS=$',' 
+  fi
+  local IFS=$','
   for cve in $TRIVY_IGNORE_LIST; do
     echo $cve >> $TRIVY_IGNOREFILE
   done
@@ -62,16 +62,21 @@ generate_images_list() {
 
 scan_template() {
   local image=$1
-  local object=$(trivy -q -f json --cache-dir ${CACHE_DIR} --ignorefile ${TRIVY_IGNOREFILE} ${image} | sed 's|null|\[\]|')
-  count=$( echo $object | jq length)
+  local object=$(trivy image -q -f json --cache-dir ${CACHE_DIR} --ignorefile ${TRIVY_IGNOREFILE} ${image} | sed 's|null|\[\]|')
+  count=$( echo $object | jq '.Results | length')
   for ((i = 0 ; i < $count ; i++)); do
-    local vuln_length=$(echo $object | jq -r --arg index "${i}" '.[($index|tonumber)].Vulnerabilities | length')
+    local vuln_length=$(echo $object | jq '.Results' | jq -r --arg index "${i}" '.[($index|tonumber)].Vulnerabilities // [] | length')
     if [[ "$vuln_length" -eq "0" ]] && [[ "$SKIP_EMPTY" == "true" ]]; then
       continue
     fi
-    echo -E "\n"Target: $(echo $object | jq -r --arg index "${i}" '.[($index|tonumber)].Target')
+    echo -E "\n"Target: $(echo $object | jq '.Results' |  jq -r --arg index "${i}" '.[($index|tonumber)].Target')
     echo "..."
-    echo $object | jq -r --arg index "${i}" '.[($index|tonumber)].Vulnerabilities[] | "\(.PkgName) \(.VulnerabilityID) \(.Severity)"' | column -t | sort -k3
+    if [[ "$vuln_length" -eq "0" ]]; then
+      # Return a non-empty default value
+      echo "No vulnerabilities found."
+      continue
+    fi
+    echo $object | jq '.Results' | jq -r --arg index "${i}" '.[($index|tonumber)].Vulnerabilities // [] | .[] | "\(.PkgName) \(.VulnerabilityID) \(.Severity)"' | column -t | sort -k3
   done
 }
 
@@ -79,7 +84,6 @@ slack_image_section() {
   local image=$1
   local header="*${image}*"
   local body=$(scan_template $image | awk '{print}' ORS='\\n')
-  if [[ -z $body ]]; then return; fi
   echo -E "{
   \"type\": \"section\",
   \"text\": {
@@ -102,7 +106,7 @@ main() {
   fi
 
   echoSection "Update trivy DB"
-  trivy --download-db-only --cache-dir ${CACHE_DIR}
+  trivy image --download-db-only --cache-dir ${CACHE_DIR}
 
   SLACK_REPORT_MESSAGE='{"blocks":[]}'
 

--- a/incubating/trivy/step.yaml
+++ b/incubating/trivy/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: trivy-scan
-  version: 0.0.3
+  version: 0.0.4
   isPublic: true
   description: The step scans the list of docker images and sends the report to a Slack webhook URL.
   sources:
@@ -87,7 +87,7 @@ spec:
   steps:
     main:
       name: scan
-      image: quay.io/codefreshplugins/trivy-scan:latest
+      image: quay.io/codefreshplugins/trivy-scan:0.0.4
       environment:
         - 'GITHUB_TOKEN=${{GITHUB_TOKEN}}'
         - 'IMAGES_LIST=${{IMAGES_LIST}}'


### PR DESCRIPTION
**Release Notes: Trivy Scanner v0.0.4**

**_Upgrade to Trivy 0.41.0_**

We have upgraded the Trivy scanner to the official Long Term Support (LTS) version 0.41.0. This version includes several performance improvements, bug fixes, and security updates. We recommend that all users upgrade to this version to take advantage of these benefits.

_**Fix for Cannot iterate over null error**_

We have fixed an issue where the scanner would return a Cannot iterate over null error when an image did not have any vulnerabilities. This error has been resolved, and the scanner will now handle these cases gracefully.

_**Fix for "SKIP EMPTY" report sending**_

We have fixed an issue where the scanner would send an empty report to the Slack channel even if the image did not have any vulnerabilities. This behavior has been changed to only send reports for images that have vulnerabilities. This change will help reduce noise in your Slack channel and make it easier to focus on images that require attention.