### PR TITLE
Fixed Critical CVE for argocd-app-status

### DIFF
--- a/incubating/argocd-app-status/CHANGELOG.md
+++ b/incubating/argocd-app-status/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Changed
 
 ### Fixed
-- PYSEC-2023-135 - upgrade certifi to 2023.7.22
-- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bullseye
+- PYSEC-2023-135 - upgrade Python module certifi to 2023.7.22
+- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bookworm
 
 ## [1.1.1] - 2023-06-03
 ### Changed

--- a/incubating/argocd-app-status/CHANGELOG.md
+++ b/incubating/argocd-app-status/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+## [1.1.2] - 2023-09-18
+### Changed
+
+### Fixed
+- PYSEC-2023-135 - upgrade certifi to 2023.7.22
+- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bullseye
+
+## [1.1.1] - 2023-06-03
+### Changed
+- Upgrade pythpn version to 3.11.3
+
+### Fixed
+- Link for application
+- Misspellings
+
+## [1.1.0] - 2023-06-01
+### Changed
+- Adding document on LOG_LEVEL and fault to error
+- Adding return parameters
+- Remove env_vars_to_export, file created for testing
+- Enumerate sync status
+- simplify query
+- updating version to reduce vulnerabilities
+- updating base image
+- increasing requests version to 2.31.0 to solve CVSS 6.1
+### Fixed
+
+
+## [1.0.1] - 2023-05-31
+- Original version
+- Adding debug ifo

--- a/incubating/argocd-app-status/Dockerfile
+++ b/incubating/argocd-app-status/Dockerfile
@@ -1,4 +1,4 @@
-FROM    python:3.11.5-slim-bullseye
+FROM    python:3.11.5-slim-bookworm
 WORKDIR /app
 COPY    requirements.txt requirements.txt
 RUN     pip3 install -r requirements.txt

--- a/incubating/argocd-app-status/Dockerfile
+++ b/incubating/argocd-app-status/Dockerfile
@@ -1,4 +1,4 @@
-FROM    python:3.11.3-slim-buster
+FROM    python:3.11.5-slim-bullseye
 WORKDIR /app
 COPY    requirements.txt requirements.txt
 RUN     pip3 install -r requirements.txt

--- a/incubating/argocd-app-status/requirements.txt
+++ b/incubating/argocd-app-status/requirements.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
-certifi==2023.5.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 docopt==0.6.2
 gql==3.4.0

--- a/incubating/argocd-app-status/step.yaml
+++ b/incubating/argocd-app-status/step.yaml
@@ -1,7 +1,7 @@
 kind: step-type
 metadata:
   name: argocd-app-status
-  version: 1.1.1
+  version: 1.1.2
   isPublic: true
   description: Get Argo CD App status and return its sybc and health status
   sources:
@@ -61,7 +61,7 @@ spec:
         },
         "IMAGE_TAG": {
           "type": "string",
-          "default": "1.1.1",
+          "default": "1.1.2",
           "description": "OPTIONAL - To overwrite the tag to use"
         }
       }


### PR DESCRIPTION
Added a  CHANGELOG.md

### Fixed
- PYSEC-2023-135 - upgrade Python module certifi to 2023.7.22
- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bookworm
