### PR TITLE
1.3.1: fix vulnerabilities

### DIFF
--- a/incubating/argo-cd-sync/CHANGELOG.md
+++ b/incubating/argo-cd-sync/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+## [1.3.1] - 2023-09-18
+### Changed
+
+### Fixed
+- CVE-2023-37920 - upgrade Python module certifi to 2023.7.22
+- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bookworm
+
+## [1.3.0] - 2023-05-19
+### Changed
+- Adding IMAGE_NAME parameter
+- Adding example
+
+### Fixed

--- a/incubating/argo-cd-sync/Dockerfile
+++ b/incubating/argo-cd-sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM    python:3.11.2-slim-buster
+FROM    python:3.11.5-slim-bookworm
 WORKDIR /app
 COPY    requirements.txt requirements.txt
 RUN     pip3 install -r requirements.txt

--- a/incubating/argo-cd-sync/requirements.txt
+++ b/incubating/argo-cd-sync/requirements.txt
@@ -1,5 +1,5 @@
 backoff==2.2.1
-certifi==2022.12.7
+certifi==2023.7.22
 charset-normalizer==3.1.0
 gql==3.4.0
 graphql-core==3.2.3

--- a/incubating/argo-cd-sync/step.yaml
+++ b/incubating/argo-cd-sync/step.yaml
@@ -1,7 +1,7 @@
 kind: step-type
 metadata:
   name: argo-cd-sync
-  version: 1.3.0
+  version: 1.3.1
   isPublic: true
   description: Syncs Argo CD apps managed by our GitOps Runtimes
   sources:
@@ -111,7 +111,7 @@ spec:
         },
         "IMAGE_TAG": {
           "type": "string",
-          "default": "1.3.0",
+          "default": "1.3.1",
           "description": "OPTIONAL - To overwrite the tag to use"
         }
       }


### PR DESCRIPTION
- Add CHANGELOG.md
- CVE-2023-37920 - upgrade Python module certifi to 2023.7.22
- CVE-2019-8457 - upgrade base image to python:3.11.5-slim-bookworm