### PR TITLE
add default audience value

### DIFF
--- a/incubating/obtain-oidc-id-token/step.yaml
+++ b/incubating/obtain-oidc-id-token/step.yaml
@@ -83,7 +83,8 @@ spec:
         "properties": {
            "AUDIENCE": {
                "type": "string",
-               "description": "the audience of the ID token. For multiple audiences, use a comma-separated list. Defaults to the address of the Codefresh platform instance (For SaaS, https://g.codefresh.io)"
+               "description": "the audience of the ID token. For multiple audiences, use a comma-separated list. Defaults to the address of the Codefresh platform instance (For SaaS, https://g.codefresh.io)",
+               "default": "https://g.codefresh.io"
            }
         }
     }


### PR DESCRIPTION
## What
added default value to `obtain-oidc-id-token` `audience` property
set it to https://g.codefresh.io

## Why
without it, current step calls would send `"aud": "${{AUDIENCE}}",` in the request

## Notes