### PR TITLE
Use same Docker image in Codecov steps

### DIFF
--- a/incubating/codecov-reporter/step.yaml
+++ b/incubating/codecov-reporter/step.yaml
@@ -89,7 +89,7 @@ spec:
         - echo CODECOV_URL=$CODECOV_URL >> /meta/env_vars_to_export
     second:
       name: "send report"
-      image: node:15.2
+      image: codefresh/cli
       environment:
         - CODECOV_API_KEY=${{CODECOV_API_KEY}}
         - WORKING_DIRECTORY=${{working_directory}}


### PR DESCRIPTION

## What

* Reduce the CI execution time needed, as all Docker layers already are cached.
* Reduce maintenance effort, as the `codefresh/cli` image will be respected.

## Why

... `codefresh/cli` also is based on Node, and uses Node 18

## Notes