### PR TITLE
Fix obtain-oidc-id-token - change shell to bash

### DIFF
--- a/incubating/obtain-oidc-id-token/step.yaml
+++ b/incubating/obtain-oidc-id-token/step.yaml
@@ -108,6 +108,7 @@ spec:
     main:
       name: obtain-oidc-id-token
       image: quay.io/codefreshplugins/curl-jq
+      shell: bash
       environment:
         - 'AUDIENCE=${{AUDIENCE}}'
       commands:


### PR DESCRIPTION
## What

## Why

## Notes