### PR TITLE
feat: Fully support Events API v2 in PagerDuty step

### DIFF
--- a/incubating/pagerduty-alert/lib/pagerduty_alert.py
+++ b/incubating/pagerduty-alert/lib/pagerduty_alert.py
@@ -1,6 +1,5 @@
 import os
-from pdpyras import APISession
-from pdpyras import ChangeEventsAPISession
+from pdpyras import APISession, EventsAPISession, ChangeEventsAPISession
 
 def main():
 

--- a/incubating/pagerduty-alert/lib/pagerduty_alert.py
+++ b/incubating/pagerduty-alert/lib/pagerduty_alert.py
@@ -13,6 +13,7 @@ def main():
     service_id = os.getenv('SERVICE_ID')
     title = os.getenv('TITLE')
     pagerduty_type = os.getenv('PAGERDUTY_ALERT_TYPE')
+    pagerduty_severity = os.getenv('PAGERDUTY_SEVERITY')
 
     if pagerduty_type == 'incident':
         session = APISession(api_token, default_from=from_email)

--- a/incubating/pagerduty-alert/lib/pagerduty_alert.py
+++ b/incubating/pagerduty-alert/lib/pagerduty_alert.py
@@ -14,6 +14,7 @@ def main():
     service_id = os.getenv('SERVICE_ID')
     title = os.getenv('TITLE')
     pagerduty_type = os.getenv('PAGERDUTY_ALERT_TYPE')
+    pagerduty_event_action = os.getenv('PAGERDUTY_EVENT_ACTION')
 
     if pagerduty_type == 'incident':
         session = APISession(api_token, default_from=from_email)

--- a/incubating/pagerduty-alert/lib/pagerduty_alert.py
+++ b/incubating/pagerduty-alert/lib/pagerduty_alert.py
@@ -13,7 +13,6 @@ def main():
     service_id = os.getenv('SERVICE_ID')
     title = os.getenv('TITLE')
     pagerduty_type = os.getenv('PAGERDUTY_ALERT_TYPE')
-    pagerduty_event_action = os.getenv('PAGERDUTY_EVENT_ACTION')
 
     if pagerduty_type == 'incident':
         session = APISession(api_token, default_from=from_email)

--- a/incubating/pagerduty-alert/lib/pagerduty_alert.py
+++ b/incubating/pagerduty-alert/lib/pagerduty_alert.py
@@ -38,6 +38,17 @@ def main():
 
         pd_incident = session.rpost('incidents', json=payload)
 
+    elif pagerduty_type == 'event':
+        session = EventsAPISession(api_token)
+
+        pd_event = session.trigger(
+            summary='{}'.format(event_summary),
+            source='{}'.format(event_source),
+            severity='{}'.format(pagerduty_severity),
+            custom_details={"Build ID":'{}'.format(cf_build_id)},
+            links=[{'href':'{}'.format(cf_build_url)}]
+        )
+
     elif pagerduty_type == 'change_event':
 
         session = ChangeEventsAPISession(api_token)

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pagerduty-alert
   version: 1.1.0
   isPublic: true
-  description: Sends Alerts (Incidents or Change Events) to PagerDuty API
+  description: Sends events to PagerDuty via the Events or REST APIs (v2)
   sources:
     - https://github.com/codefresh-io/steps/tree/master/incubating/pagerduty-alert
   stage: incubating

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -78,6 +78,7 @@ spec:
           "default": "change_event",
           "enum": [
             "incident",
+            "event",
             "change_event"
           ]
         },

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -123,7 +123,7 @@ spec:
   stepsTemplate: |-
     pagerduty-alert:
       name: pagerduty-alert
-      image: quay.io/codefreshplugins/pagerduty-alert:1.0.2
+      image: quay.io/codefreshplugins/pagerduty-alert:1.1.0
       environment:
       [[ range $key, $val := .Arguments ]]
         - '[[ $key ]]=[[ $val ]]'

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -81,6 +81,17 @@ spec:
             "change_event"
           ]
         },
+        "PAGERDUTY_SEVERITY": {
+          "type": "string",
+          "description": "Optional for event type, PagerDuty Severity",
+          "default": "error",
+          "enum": [
+            "critical",
+            "error",
+            "warning",
+            "info"
+          ]
+        },
         "ASSIGNEE_USER_ID": {
           "type": "string",
           "description": "Optional for incident type when an escalation policy is in place, PagerDuty User ID"

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: pagerduty-alert
-  version: 1.0.2
+  version: 1.1.0
   isPublic: true
   description: Sends Alerts (Incidents or Change Events) to PagerDuty API
   sources:

--- a/incubating/pagerduty-alert/step.yaml
+++ b/incubating/pagerduty-alert/step.yaml
@@ -36,6 +36,16 @@ metadata:
             FROM_EMAIL: dustin@codefresh.io
             TITLE: "Codefresh Build Failed: ${{CF_BUILD_URL}}"
             SERVICE_ID: 87hsd2fh38gh7g
+    - description: submit-event
+      workflow:
+        SubmitEvent:
+          type: pagerduty-alert
+          arguments:
+            API_TOKEN: x2392fhhgdys867gt3fd
+            PAGERDUTY_ALERT_TYPE: event
+            PAGERDUTY_SEVERITY: error
+            EVENT_SOURCE: Codefresh
+            EVENT_SUMMARY: "Codefresh Build Failed: ${{CF_BUILD_URL}}"
     - description: submit-change-event
       workflow:
         SubmitChangeEvent:


### PR DESCRIPTION
## What

- Implement full support for PagerDuty's Events API v2.
- Enable triggering incidents using the Events API.
- Add a new `event` value to the `PAGERDUTY_ALERT_TYPE` enum.
- Add a new `PAGERDUTY_SEVERITY` argument.
- Update the step specification.
- Update the step documentation.
- Bump the step's minor version.
- Maintain backwards compatibility.
- Resolve #696.

## Why

- PagerDuty's Events API was only supported for creating change events.
- Triggering incidents was only possible with PagerDuty's REST API.
- More details in the linked issue.

## Notes

- I have not tested this PR.
- I'm a new contributor to this repo and might have missed something.
- This PR will make the wiki page ([link](https://github.com/caronc/apprise/wiki/Notify_pagerduty)) out of date, but I don't think I have permission to update it.