### PR TITLE
Add max file upload argument to test-reporting step

### DIFF
--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -45,6 +45,7 @@ metadata:
               branch: ${{CF_BRANCH_TAG_NORMALIZED}}
               report_dir: mochawesome-report
               report_index_file: mochawesome.html
+              image_tag: 1.2.0-scmecr-19339add-max-file-upload-argument
 
 spec:
   arguments: |-
@@ -96,13 +97,17 @@ spec:
             "cf_api_retries": {
                 "type": "integer",
                 "description": "The number of times to retry if a Codefresh API call fails. The default is 0"
+            },
+            "image_tag": {
+                "type": "string",
+                "description": "The version of test reporting image. The default is 1.2.0"
             }
         }
     }
   stepsTemplate: |-
     first:
       title: Generate test reporting
-      image: codefresh/cf-docker-test-reporting:1.2.0-scmecr-19339add-max-file-upload-argument
+      image: codefresh/cf-docker-test-reporting:[[ .Arguments.image_tag ]]
       environment:
         [[ if .Arguments.allure_dir ]]
           - ALLURE_DIR=[[ .Arguments.allure_dir ]]

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -45,6 +45,7 @@ metadata:
               branch: ${{CF_BRANCH_TAG_NORMALIZED}}
               report_dir: mochawesome-report
               report_index_file: mochawesome.html
+              max_upload_size_mb: 1000
 
 spec:
   arguments: |-
@@ -113,6 +114,9 @@ spec:
         [[ end ]]
         [[ if .Arguments.storage_integration ]]
           - CF_STORAGE_INTEGRATION=[[ .Arguments.storage_integration ]]
+        [[ end ]]
+        [[ if .Arguments.max_upload_size_mb ]]
+          - MAX_UPLOAD_SIZE_MB=[[ .Arguments.max_upload_size_mb ]]
         [[ end ]]
           - CF_STEP_NAME=first
           - CF_VOLUME_PATH=/meta

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -77,6 +77,10 @@ spec:
                 "type": "string",
                 "description": "Directory with test report files"
             },
+            "report_path": {
+                "type": "string",
+                "description": "Path where the report files are saved in the bucket"
+            },
             "report_index_file": {
                 "type": "string",
                 "description": "Root file that will be open in report"
@@ -88,6 +92,10 @@ spec:
             "max_upload_size_mb": {
                 "type": "integer",
                 "description": "Max upload size in MB. The default is 1000MB"
+            },
+            "cf_api_retries": {
+                "type": "integer",
+                "description": "The number of times to retry if a Codefresh API call fails. The default is 0"
             }
         }
     }
@@ -108,6 +116,9 @@ spec:
         [[ if .Arguments.report_dir ]]
           - REPORT_DIR=[[ .Arguments.report_dir ]]
         [[ end ]]
+        [[ if .Arguments.report_path ]]
+          - REPORT_PATH=[[ .Arguments.report_path ]]
+        [[ end ]]
         [[ if .Arguments.report_index_file ]]
           - REPORT_INDEX_FILE=[[ .Arguments.report_index_file ]]
         [[ end ]]
@@ -119,6 +130,9 @@ spec:
         [[ end ]]
         [[ if .Arguments.max_upload_size_mb ]]
           - MAX_UPLOAD_SIZE_MB=[[ .Arguments.max_upload_size_mb ]]
+        [[ end ]]
+        [[ if .Arguments.cf_api_retries ]]
+          - CF_API_RETRIES=[[ .Arguments.cf_api_retries ]]
         [[ end ]]
           - CF_STEP_NAME=first
           - CF_VOLUME_PATH=/meta

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -94,7 +94,7 @@ spec:
   stepsTemplate: |-
     first:
       title: Generate test reporting
-      image: codefresh/cf-docker-test-reporting:test-report-link
+      image: codefresh/cf-docker-test-reporting:scmecr-19339add-max-file-upload-argument
       environment:
         [[ if .Arguments.allure_dir ]]
           - ALLURE_DIR=[[ .Arguments.allure_dir ]]

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -5,7 +5,7 @@ metadata:
   version: 1.2.0
   title: Test reporting
   isPublic: true
-  description: Upload test report to some your storage integration.
+  description: Upload test report data to your storage integration.
   sources:
     - 'https://github.com/codefresh-io/cf-docker-test-reporting'
   stage: incubating
@@ -45,8 +45,6 @@ metadata:
               branch: ${{CF_BRANCH_TAG_NORMALIZED}}
               report_dir: mochawesome-report
               report_index_file: mochawesome.html
-              image_tag: 1.2.0-scmecr-19339add-max-file-upload-argument
-
 spec:
   arguments: |-
     {
@@ -92,15 +90,18 @@ spec:
             },
             "max_upload_size_mb": {
                 "type": "integer",
-                "description": "Max upload size in MB. The default is 1000MB"
+                "description": "Max upload size in MB",
+                "default": 1000
             },
             "cf_api_retries": {
                 "type": "integer",
-                "description": "The number of times to retry if a Codefresh API call fails. The default is 0"
+                "description": "The number of times to retry if a Codefresh API call fails",
+                "default": 0
             },
             "image_tag": {
                 "type": "string",
-                "description": "The version of test reporting image. The default is 1.2.0"
+                "description": "The version of test reporting image",
+                "default": "1.2.0-scmecr-19339add-max-file-upload-argument"
             }
         }
     }

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: test-reporting
-  version: 1.1.4
+  version: 1.2.0
   title: Test reporting
   isPublic: true
   description: Upload test report to some your storage integration.

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -102,7 +102,7 @@ spec:
   stepsTemplate: |-
     first:
       title: Generate test reporting
-      image: codefresh/cf-docker-test-reporting:scmecr-19339add-max-file-upload-argument
+      image: codefresh/cf-docker-test-reporting:1.2.0-scmecr-19339add-max-file-upload-argument
       environment:
         [[ if .Arguments.allure_dir ]]
           - ALLURE_DIR=[[ .Arguments.allure_dir ]]

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -45,7 +45,6 @@ metadata:
               branch: ${{CF_BRANCH_TAG_NORMALIZED}}
               report_dir: mochawesome-report
               report_index_file: mochawesome.html
-              max_upload_size_mb: 1000
 
 spec:
   arguments: |-
@@ -85,8 +84,11 @@ spec:
             "branch" : {
                 "type": "string",
                 "description": "Normalized branch name"
+            },
+            "max_upload_size_mb": {
+                "type": "integer",
+                "description": "Max upload size in MB. The default is 1000MB"
             }
-
         }
     }
   stepsTemplate: |-

--- a/incubating/test-reporting/step.yaml
+++ b/incubating/test-reporting/step.yaml
@@ -101,7 +101,7 @@ spec:
             "image_tag": {
                 "type": "string",
                 "description": "The version of test reporting image",
-                "default": "1.2.0-scmecr-19339add-max-file-upload-argument"
+                "default": "1.2.0"
             }
         }
     }


### PR DESCRIPTION
## What

The Max File Upload is currently hardcoded to 1000MB which can sometimes not be enough in certain circumstances.

## Why

Sometimes the upload can be over 1000MB which makes the step fail. Making it an argument allows users to specify the upload limit so it can be increased. It also allows users to reduce the value to ensure they don't upload too much by mistake.

## Notes

I noticed that the docker image tag used on this step is ~4 years old so updating to my new tag includes some other changes to the `cf-docker-test-reporting` image. I've added `cf_api_retries` and `report_path` arguments as they were added to the docker test reporting executable. I've also added the `image_tag` argument as an escape hatch just in case it's necessary to target a specific image tag in the future.

## Testing

I've tested this locally against a pre-release build of the docker image and it works as expected.