### PR TITLE
Fix image path, include Octopus in step title

### DIFF
--- a/incubating/octopusdeploy-create-package/step.yaml
+++ b/incubating/octopusdeploy-create-package/step.yaml
@@ -3,7 +3,7 @@ kind: step-type
 metadata:
   name: octopusdeploy-create-package
   version: 1.0.1
-  title: Create a package in Octopus Deploy
+  title: Create Octopus Deploy package
   isPublic: true
   description: Creates a zip package in the format expected by Octopus Deploy
   sources:

--- a/incubating/octopusdeploy-create-package/step.yaml
+++ b/incubating/octopusdeploy-create-package/step.yaml
@@ -2,8 +2,8 @@ version: "1.0"
 kind: step-type
 metadata:
   name: octopusdeploy-create-package
-  version: 1.0.0
-  title: Create a package
+  version: 1.0.1
+  title: Create a package in Octopus Deploy
   isPublic: true
   description: Creates a zip package in the format expected by Octopus Deploy
   sources:

--- a/incubating/octopusdeploy-deploy-release-tenanted/step.yaml
+++ b/incubating/octopusdeploy-deploy-release-tenanted/step.yaml
@@ -2,7 +2,7 @@ version: "1.0"
 kind: step-type
 metadata:
   name: octopusdeploy-deploy-release-tenanted
-  version: 1.0.0
+  version: 1.0.1
   title: Deploy a tenanted release in Octopus Deploy
   isPublic: true
   description: Deploy a tenanted release in Octopus Deploy

--- a/incubating/octopusdeploy-deploy-release-tenanted/step.yaml
+++ b/incubating/octopusdeploy-deploy-release-tenanted/step.yaml
@@ -14,7 +14,7 @@ metadata:
     - deployment
   icon:
     type: svg
-    url: "https://cdn.jsdelivr.net/gh/codefresh-io/steps/incubating/octopusdeploy-deploy-release/deploy-release-tenanted.svg"
+    url: "https://cdn.jsdelivr.net/gh/codefresh-io/steps/incubating/octopusdeploy-deploy-release-tenanted/deploy-release-tenanted.svg"
     background: "#F4F6F8"
   maintainers:
     - name: OctopusDeploy


### PR DESCRIPTION
## What
Fix the image path for Deploy Tenanted Release. Change the title of the Create Package step to include Octopus Deploy.

## Why
The image is currently missing for the Deploy Tenanted Release step due to an invalid path. The title of the Create Package step isn't clear that the step is to be used for Octopus.