### PR TITLE
Snow CVE

### DIFF
--- a/incubating/service-now/CHANGELOG.md
+++ b/incubating/service-now/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.2.5] - 2025-01-02
+### Changed
+### Fixed
+- CVE-2023-4911 - upgrade glibc
+- CVE-2023-6246 - upgrade glibc
+- CVE-2024-45492 - Upgrade expat/libexpat1
+- CVE-2024-45491 - Upgrade expat/libexpat1
+- CVE-2024-37371 - Upgrade krb5
+
 ## [1.2.4] - 2023-09-21
 ### Changed
 - Change logging mechanism

--- a/incubating/service-now/CHANGELOG.md
+++ b/incubating/service-now/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [1.2.5] - 2025-01-02
-### Changed
+
 ### Fixed
 - CVE-2023-4911 - upgrade glibc
 - CVE-2023-6246 - upgrade glibc

--- a/incubating/service-now/Dockerfile
+++ b/incubating/service-now/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.5-slim-bookworm
+FROM python:3.13.1-slim-bookworm
 RUN pip3 install requests
 
 COPY lib/snow.py /snow/snow.py

--- a/incubating/service-now/step.yaml
+++ b/incubating/service-now/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: service-now
-  version: 1.2.4
+  version: 1.2.5
   isPublic: true
   description: Integration with ServiceNow Change Management
   sources:
@@ -86,7 +86,7 @@ spec:
         },
         "SN_IMAGE_VERSION": {
           "type": "string",
-          "default": "1.2.4",
+          "default": "1.2.5",
           "description": "Version of the ServiceNow image to use, Docker image tag."
         },
         "SN_INSTANCE": {


### PR DESCRIPTION
## What
Fixed Critical CVEs

## Why
Security

## Notes
Fixed:

- CVE-2023-4911 - upgrade glibc
- CVE-2023-6246 - upgrade glibc
- CVE-2024-45492 - Upgrade expat/libexpat1
- CVE-2024-45491 - Upgrade expat/libexpat1
- CVE-2024-37371 - Upgrade krb5