### PR TITLE
added a simple regex to find jira issue in field by a given regex

### DIFF
--- a/incubating/jira-issue-manager/script/jira_issue_manager.py
+++ b/incubating/jira-issue-manager/script/jira_issue_manager.py
@@ -66,8 +66,11 @@ def environment_setup():
     # Logic here to use the regex to grab the jira issue key and assign it to issue
     jira_issue_source_field = StepUtility.getEnvironmentVariable('JIRA_ISSUE_SOURCE_FIELD', env)
     jira_issue_source_field_regex = StepUtility.getEnvironmentVariable('JIRA_ISSUE_SOURCE_FIELD_REGEX', env)
-    ## TODO - Brandon - need to do regex work here
-    issue = jira_issue_source_field
+
+    if jira_issue_source_field_regex:
+        issue = re.match(jira_issue_source_field_regex, jira_issue_source_field).group(0)
+    else:
+        issue = jira_issue_source_field
 
     # Issue fields below
     # Retrieve the project environment variable and add the project to a dict representation

--- a/incubating/jira-issue-manager/step.yaml
+++ b/incubating/jira-issue-manager/step.yaml
@@ -2,7 +2,7 @@ kind: step-type
 version: '1.0'
 metadata:
   name: jira-issue-manager
-  version: 1.0.11
+  version: 1.0.12
   title: Jira Issue Manager
   isPublic: true
   description: Create, Update, & Validate Jira Issues
@@ -12,6 +12,7 @@ metadata:
   stage: incubating
   maintainers:
     - name: Brandon Phillips
+    - name: Dustin Van Buskirk
   categories:
     - build
   official: true
@@ -245,7 +246,7 @@ spec:
   stepsTemplate: |-
     main:
         name: jira-issue-manager
-        image: quay.io/codefreshplugins/jira-issue-manager:1.0.11
+        image: quay.io/codefreshplugins/jira-issue-manager:1.0.12
         environment:
         [[ range $key, $val := .Arguments ]]
           - '[[ $key ]]=[[ $val ]]'


### PR DESCRIPTION
## What

Adding in regex support. 

## Why

This was a todo and is now required as it is going to be used by prospect/customer.

## Notes

Test locally via temporary step dustinvanbuskirk/jira-issue-manager

``` yaml
version: '1.0'

steps:
  JiraCommentCreate:
    title: Add Jira Comment
    type: dustinvanbuskirk/jira-issue-manager
    arguments:
      JIRA_BASE_URL: 'https://cf-demo-jira.atlassian.net/'
      JIRA_USERNAME: '${{JIRA_USERNAME}}'
      JIRA_API_KEY: '${{JIRA_API_KEY}}'
      JIRA_ISSUE_SOURCE_FIELD: 'SDD-1-My-Feature-Branch'
      JIRA_ISSUE_SOURCE_FIELD_REGEX: '.*(?=-)-[0-9]+'
      ACTION: comment_create
      COMMENT_BODY: Test from codefresh pipeline
```

```
[2025-01-09T19:45:41.079Z] Status: Downloaded newer image for dustinvanbuskirk/jira-issue-manager:1.0.12
[2025-01-09T19:45:43.542Z] Step Action: comment_create

[2025-01-09T19:45:43.542Z] Create comment
[2025-01-09T19:45:43.757Z] Comment id: 10078
```

Output to SSD-1

<img width="818" alt="Screenshot 2025-01-09 at 11 56 53 AM" src="https://github.com/user-attachments/assets/f2f20c0d-22d9-401a-b4ca-cfbdc3092fb9" />